### PR TITLE
updated authredirect uri according to s3 depreciation plan

### DIFF
--- a/workspaces-utils.js
+++ b/workspaces-utils.js
@@ -27,7 +27,7 @@ S3BucketName      = "xxxxxxxxxxxx";
 
 USER_API_URL  = "https://"+APIGatewayId+".execute-api."+RegionName+".amazonaws.com/Prod/user/"
 ADMIN_API_URL = "https://"+APIGatewayId+".execute-api."+RegionName+".amazonaws.com/Prod/admin/"
-authRedirect  = "https://"+CognitoDomainName+".auth."+RegionName+".amazoncognito.com/login?response_type=token&client_id="+CognitoClientId+"&redirect_uri=https%3A%2F%2F"+S3BucketName+".s3.amazonaws.com%2Findex.html";
+authRedirect  = "https://"+CognitoDomainName+".auth."+RegionName+".amazoncognito.com/login?response_type=token&client_id="+CognitoClientId+"&redirect_uri=https%3A%2F%2F"+S3BucketName+".s3."+RegionName+".amazonaws.com%2Findex.html";
 
 function parseJWT(token) {
  var base64Url = token.split('.')[1];

--- a/workspaces-utils.js
+++ b/workspaces-utils.js
@@ -27,7 +27,7 @@ S3BucketName      = "xxxxxxxxxxxx";
 
 USER_API_URL  = "https://"+APIGatewayId+".execute-api."+RegionName+".amazonaws.com/Prod/user/"
 ADMIN_API_URL = "https://"+APIGatewayId+".execute-api."+RegionName+".amazonaws.com/Prod/admin/"
-authRedirect  = "https://"+CognitoDomainName+".auth."+RegionName+".amazoncognito.com/login?response_type=token&client_id="+CognitoClientId+"&redirect_uri=https%3A%2F%2Fs3-"+RegionName+".amazonaws.com%2F"+S3BucketName+"%2Findex.html";
+authRedirect  = "https://"+CognitoDomainName+".auth."+RegionName+".amazoncognito.com/login?response_type=token&client_id="+CognitoClientId+"&redirect_uri=https%3A%2F%2F"+S3BucketName+".s3.amazonaws.com%2Findex.html";
 
 function parseJWT(token) {
  var base64Url = token.split('.')[1];


### PR DESCRIPTION
*Description of changes:*
The authRedirect uri was updated in workspaces-utils.js to work with s3 virtual-hosted style references as outlined in the S3 documentation: https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html

The callback URL should be updated in this blog:
https://aws.amazon.com/blogs/desktop-and-application-streaming/creating-a-self-service-portal-for-amazon-workspaces-end-users/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
